### PR TITLE
Common node name scheme update to Jenkinsfile

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -3,6 +3,7 @@ def machine = 'none'
 def HOME = 'none'
 def caseList = ''
 // Location of the custom workspaces for each machine in the CI system.  They are persitent for each iteration of the PR.
+def NodeName = [Hera: 'Hera-EMC', Orion: 'Orion-EMC', Hercules: 'Hercules-EMC', Gaea: 'Gaea']
 def custom_workspace = [hera: '/scratch1/NCEPDEV/global/CI', orion: '/work2/noaa/stmp/CI/ORION', hercules: '/work2/noaa/stmp/CI/HERCULES', gaea: '/gpfs/f5/epic/proj-shared/global/CI']
 def repo_url = 'git@github.com:NOAA-EMC/global-workflow.git'
 def STATUS = 'Passed'
@@ -70,13 +71,13 @@ pipeline {
         }
 
         stage('2. Get Common Workspace') {
-            agent { label "${machine}-emc" }
+            agent { label NodeName[machine].toLowerCase() }
             steps {
                 script {
                     Machine = machine[0].toUpperCase() + machine.substring(1)
                     echo "Getting Common Workspace for ${Machine}"
                     ws("${custom_workspace[machine]}/${env.CHANGE_ID}") {
-                        properties([parameters([[$class: 'NodeParameterDefinition', allowedSlaves: ['built-in', 'Hera-EMC', 'Orion-EMC'], defaultSlaves: ['built-in'], name: '', nodeEligibility: [$class: 'AllNodeEligibility'], triggerIfResult: 'allCases']])])
+                        properties([parameters([[$class: 'NodeParameterDefinition', allowedSlaves: ['built-in', 'Hercules-EMC', 'Hera-EMC', 'Orion-EMC', 'Gaea'], defaultSlaves: ['built-in'], name: '', nodeEligibility: [$class: 'AllNodeEligibility'], triggerIfResult: 'allCases']])])
                         HOME = "${WORKSPACE}"
                         sh(script: "mkdir -p ${HOME}/RUNTESTS;rm -Rf ${HOME}/RUNTESTS/*")
                         sh(script: """${GH} pr edit ${env.CHANGE_ID} --repo ${repo_url} --add-label "CI-${Machine}-Building" --remove-label "CI-${Machine}-Ready" """)
@@ -88,7 +89,7 @@ pipeline {
 
         stage('3. Build System') {
             matrix {
-                agent { label "${machine}-emc" }
+                agent { label NodeName[machine].toLowerCase() }
                 //options {
                 //    throttle(['global_matrix_build'])
                 //}
@@ -173,7 +174,7 @@ pipeline {
         stage('4. Run Tests') {
             failFast false 
             matrix {
-                agent { label "${machine}-emc" }
+                agent { label NodeName[machine].toLowerCase() }
                 axes {
                     axis {
                         name 'Case'
@@ -264,7 +265,7 @@ pipeline {
                    STATUS == 'Passed'
                 }
             }
-            agent { label "${machine}-emc" }
+            agent { label NodeName[machine].toLowerCase() }
             steps {
                 script {
                     try {


### PR DESCRIPTION
# Description

A few changes to allow the Jenkins node named **Gaea** to work with the Global-Workflow CI Pipeline

# Type of change
- Maintenance (code refactor, clean-up, new CI test, etc.)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

This has not been tested because the Gaea node has not been activated to work with the Global-Workflow
(chicken before the egg problem)


